### PR TITLE
Add shutdown guest ( to relaese dhcp ) on destroyVM if no static IP

### DIFF
--- a/lib/kitchen/driver/vsphere.rb
+++ b/lib/kitchen/driver/vsphere.rb
@@ -12,6 +12,7 @@ module Kitchen
       default_config :machine_options,
         :start_timeout => 600,
         :create_timeout => 600,
+        :stop_timeout => 600,
         :ready_timeout => 90,
         :bootstrap_options => {
           :use_linked_clone => true,


### PR DESCRIPTION
When vm get thier Ip on dhcp and destroy via Kitchen vsphere. Ip is not released on PowerOff but by 
shutingdown.