### PR TITLE
Use driver instance name when generating vSphere name

### DIFF
--- a/lib/kitchen/driver/vsphere.rb
+++ b/lib/kitchen/driver/vsphere.rb
@@ -27,8 +27,12 @@ module Kitchen
           }
         }
 
+      default_config(:vsphere_name) do |driver|
+        "#{driver.instance.name}-#{SecureRandom.hex(4)}"
+      end
+
       def create(state)
-        state[:vsphere_name] ||= "kitchen-#{SecureRandom.hex(4)}"
+        state[:vsphere_name] = config[:vsphere_name] 
         state[:username] = config[:machine_options][:bootstrap_options][:ssh][:user]
         state[:password] = config[:machine_options][:bootstrap_options][:ssh][:password]
         config[:server_name] = state[:vsphere_name]


### PR DESCRIPTION
By default the kitchen driver gives each VM a name of "kitchen-XXXX".  When using an ESXi server with many users and CI, it's tough to tell to which suite an instance belongs.

This PR makes this a bit easier by using the instance name by default, and allowing a user to specify a custom name in driver.vsphere_name

NOTES:
- Use similar pattern as kitchen-vagrant to generate a hostname (but appending random 4 digits for uniqueness).
- I looked at using the pattern @mwrock used for kitchen-vsphere, but its a bit more complex than might be required. However it'd be easy to use that instead.