### PR TITLE
(On behalf of Lexmark) Fix custom specs, IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,6 @@ These are settings set at the root of `machine_options`. Chances are the default
 - `create_timeout` - number of seconds to wait for a machine to be accessible after initiating provisioning (default 10 minutes)
 - `ready_timeout` - number of seconds to wait for customization to complete and vmware tools to come on line (default 5 minutes)
 
-## Other options
-
-- `ipv4_only` - whether a VM must have an IPv4 address before being considered ready. Default value: false
-
 ## More config examples
 
 ### Static IP and two additional disks of 20 and 50GB
@@ -244,7 +240,6 @@ driver_config:
     start_timeout: 600
     create_timeout: 600
     ready_timeout: 90
-    ipv4_only: false
     bootstrap_options:
       use_linked_clone: true
       datacenter: 'DC'

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ This will use chef-zero and needs no chef server (only works for ssh). Note that
 - `[:memory_mb]` - number of megabytes to allocate for machine
 - `[:host]` - `{cluster}`/`{host}` to use during provisioning
 - `[:resource_pool]` - `{cluster}`/`{resource pool}` to use during provisioning
-- `[:additional_disk_size_gb]` - an array of numbers, each signifying the number of gigabytes to assign to an additional disk (*his requires a datastore to be specified*)
+- `[:additional_disk_size_gb]` - an array of numbers, each signifying the number of gigabytes to assign to an additional disk (*this requires a datastore to be specified*)
 - `[:ssh][:user]` user to use for ssh/winrm (defaults to root on linux/administrator on windows)
 - `[:ssh][:password]` - password to use for ssh/winrm
 - `[:ssh][:paranoid]` - specifies the strictness of the host key verification checking
 - `[:ssh][:port]` port to use for ssh/winrm (defaults to 22 for ssh or 5985 for winrm)
-- `[:convergence_options][:install_msi_url]` - url to chef client msi to use (defaults to latest) 
-- `[:convergence_options][:install_sh_url]` - the bach script to install chef client on linux (defaults to latest)
+- `[:convergence_options][:install_msi_url]` - url to chef client msi to use (defaults to latest)
+- `[:convergence_options][:install_sh_url]` - the bash script to install chef client on linux (defaults to latest)
 - `[:customization_spec][:ipsettings][:ip]` static ip to assign to machine
 - `[:customization_spec][:ipsettings][:subnetMask]` - subnet to use
 - `[:customization_spec][:ipsettings][:gateway]` - array of possible gateways to use (this will most often be an array of 1)
@@ -110,6 +110,10 @@ These are settings set at the root of `machine_options`. Chances are the default
 - `start_timeout` - number of seconds to wait for a machine to be accessible after a restart (default 10 minutes)
 - `create_timeout` - number of seconds to wait for a machine to be accessible after initiating provisioning (default 10 minutes)
 - `ready_timeout` - number of seconds to wait for customization to complete and vmware tools to come on line (default 5 minutes)
+
+## Other options
+
+- `ipv4_only` - whether a VM must have an IPv4 address before being considered ready. Default value: false
 
 ## More config examples
 
@@ -240,6 +244,7 @@ driver_config:
     start_timeout: 600
     create_timeout: 600
     ready_timeout: 90
+    ipv4_only: false
     bootstrap_options:
       use_linked_clone: true
       datacenter: 'DC'

--- a/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
+++ b/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
@@ -144,7 +144,7 @@ module ChefProvisioningVsphere
             :nicSettingMap => cust_adapter_mapping
           )
         else
-          vsphere_helper.find_customization_spec(cust_options)
+          vsphere_helper.find_customization_spec(options[:customization_spec])
         end
       end
     end

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -484,7 +484,7 @@ module ChefProvisioningVsphere
         if action_handler.should_perform_actions
           action_handler.report_progress "waiting for #{machine_spec.name} (#{vm.config.instanceUuid} on #{driver_url}) to be ready ..."
           until remaining_wait_time(machine_spec, machine_options) < 0 ||
-            (vm.guest.toolsRunningStatus == "guestToolsRunning" && vm.guest.ipAddress && (!machine_options[:ipv4_only] || IPAddr.new(vm.guest.ipAddress).ipv4?)) do
+            (vm.guest.toolsRunningStatus == "guestToolsRunning" && vm.guest.ipAddress && !vm.guest.ipAddress.empty?) do
             print "."
             sleep 5
           end

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -46,7 +46,7 @@ module ChefProvisioningVsphere
       super(driver_url, config)
 
       uri = URI(driver_url)
-      @connect_options = { 
+      @connect_options = {
         provider: 'vsphere',
         host: uri.host,
         port: uri.port,
@@ -131,7 +131,7 @@ module ChefProvisioningVsphere
 
       action_handler.report_progress full_description(
         machine_spec, bootstrap_options)
-      
+
       vm = find_or_create_vm(bootstrap_options, machine_spec, action_handler)
 
       add_machine_spec_location(vm, machine_spec)
@@ -258,7 +258,7 @@ module ChefProvisioningVsphere
       # This may just be the ip of a newly cloned machine
       # Customization below may change this to a valid ip
       wait_until_ready(action_handler, machine_spec, machine_options, vm)
-      
+
       if !machine_spec.location['ipaddress'] || !has_ip?(machine_spec.location['ipaddress'], vm)
         # find the ip we actually want
         # this will be the static ip to assign
@@ -303,7 +303,7 @@ module ChefProvisioningVsphere
 
     def attempt_ip(machine_options, action_handler, vm, machine_spec)
       vm_ip = ip_to_bootstrap(machine_options[:bootstrap_options], vm)
-      
+
       wait_for_ip(vm, machine_options, action_handler)
 
       unless has_ip?(vm_ip, vm)
@@ -325,6 +325,7 @@ module ChefProvisioningVsphere
 
     def wait_for_domain(bootstrap_options, vm, machine_spec, action_handler)
       return unless bootstrap_options[:customization_spec]
+      return unless bootstrap_options[:customization_spec].is_a?(Hash) || bootstrap_options[:customization_spec].is_a?(Cheffish::MergedConfig)
       return unless bootstrap_options[:customization_spec][:domain]
 
       domain = bootstrap_options[:customization_spec][:domain]
@@ -450,7 +451,8 @@ module ChefProvisioningVsphere
     def has_static_ip(bootstrap_options)
       if bootstrap_options.has_key?(:customization_spec)
         bootstrap_options = bootstrap_options[:customization_spec]
-        if bootstrap_options.has_key?(:ipsettings)
+        if (bootstrap_options.is_a?(Hash) || bootstrap_options.is_a?(Cheffish::MergedConfig)) &&
+          bootstrap_options.has_key?(:ipsettings)
           bootstrap_options = bootstrap_options[:ipsettings]
           if bootstrap_options.has_key?(:ip)
             return true
@@ -465,7 +467,7 @@ module ChefProvisioningVsphere
         (machine_options[:start_timeout] || 600) -
           (Time.now.utc - Time.parse(machine_spec.location['started_at']))
       else
-        (machine_options[:create_timeout] || 600) - 
+        (machine_options[:create_timeout] || 600) -
          (Time.now.utc - Time.parse(machine_spec.location['allocated_at']))
       end
     end
@@ -475,7 +477,7 @@ module ChefProvisioningVsphere
         if action_handler.should_perform_actions
           action_handler.report_progress "waiting for #{machine_spec.name} (#{vm.config.instanceUuid} on #{driver_url}) to be ready ..."
           until remaining_wait_time(machine_spec, machine_options) < 0 ||
-            (vm.guest.toolsRunningStatus == "guestToolsRunning" && !vm.guest.ipAddress.nil? && vm.guest.ipAddress.length > 0) do
+            (vm.guest.toolsRunningStatus == "guestToolsRunning" && vm.guest.ipAddress && (!machine_options[:ipv4_only] || IPAddr.new(vm.guest.ipAddress).ipv4?)) do
             print "."
             sleep 5
           end
@@ -511,12 +513,12 @@ module ChefProvisioningVsphere
       additional_disk_size_gb = bootstrap_options[:additional_disk_size_gb]
       if !additional_disk_size_gb.is_a?(Array)
         additional_disk_size_gb = [additional_disk_size_gb]
-      end        
+      end
 
       additional_disk_size_gb.each do |size|
         size = size.to_i
         next if size == 0
-        if bootstrap_options[:datastore].to_s.empty? 
+        if bootstrap_options[:datastore].to_s.empty?
           raise ':datastore must be specified when adding a disk to a cloned vm'
         end
         task = vm.ReconfigVM_Task(
@@ -538,7 +540,7 @@ module ChefProvisioningVsphere
 
     def vsphere_helper
       @vsphere_helper ||= VsphereHelper.new(
-        connect_options, 
+        connect_options,
         config[:machine_options][:bootstrap_options][:datacenter]
       )
     end
@@ -556,11 +558,11 @@ module ChefProvisioningVsphere
       end
 
       transport = transport_for(
-        machine_spec, 
+        machine_spec,
         machine_options[:bootstrap_options][:ssh]
       )
       strategy = convergence_strategy_for(machine_spec, machine_options)
-      
+
       if machine_spec.location['is_windows']
         Chef::Provisioning::Machine::WindowsMachine.new(
           machine_spec, transport, strategy)
@@ -620,8 +622,8 @@ module ChefProvisioningVsphere
     end
 
     def transport_for(
-      machine_spec, 
-      remoting_options, 
+      machine_spec,
+      remoting_options,
       ip = machine_spec.location['ipaddress']
     )
       if machine_spec.location['is_windows']
@@ -641,7 +643,7 @@ module ChefProvisioningVsphere
       }
 
       Chef::Provisioning::Transport::WinRM.new(
-        "http://#{host}:5985/wsman",
+        URI::HTTP.build(:host => host, :port => 5985, :path => '/wsman').to_s,
         :plaintext,
         winrm_options,
         config

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -329,6 +329,9 @@ module ChefProvisioningVsphere
       domain = if bootstrap_options[:customization_spec].is_a?(String) && is_windows?(vm)
         spec = vsphere_helper.find_customization_spec(bootstrap_options[:customization_spec])
         spec.identity.identification.joinDomain
+      elsif bootstrap_options[:customization_spec].is_a?(String) && !is_windows?(vm)
+        spec = vsphere_helper.find_customization_spec(bootstrap_options[:customization_spec])
+        spec.identity.domain
       else
         bootstrap_options[:customization_spec][:domain]
       end

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -314,7 +314,7 @@ module ChefProvisioningVsphere
           msg << ' and tools state is '
           msg << vm.guest.toolsRunningStatus
           msg << '. powering up server...'
-          action_handler.report_progress(msg.join)
+          action_handler.report_progress(msg)
           vsphere_helper.start_vm(vm)
         else
           restart_server(action_handler, machine_spec, machine_options)

--- a/lib/kitchen/driver/vsphere.rb
+++ b/lib/kitchen/driver/vsphere.rb
@@ -14,6 +14,7 @@ module Kitchen
         :create_timeout => 600,
         :stop_timeout => 600,
         :ready_timeout => 90,
+        :ipv4_only => false,
         :bootstrap_options => {
           :use_linked_clone => true,
           :ssh => {
@@ -32,7 +33,7 @@ module Kitchen
       end
 
       def create(state)
-        state[:vsphere_name] = config[:vsphere_name] 
+        state[:vsphere_name] = config[:vsphere_name]
         state[:username] = config[:machine_options][:bootstrap_options][:ssh][:user]
         state[:password] = config[:machine_options][:bootstrap_options][:ssh][:password]
         config[:server_name] = state[:vsphere_name]

--- a/lib/kitchen/driver/vsphere.rb
+++ b/lib/kitchen/driver/vsphere.rb
@@ -14,7 +14,6 @@ module Kitchen
         :create_timeout => 600,
         :stop_timeout => 600,
         :ready_timeout => 90,
-        :ipv4_only => false,
         :bootstrap_options => {
           :use_linked_clone => true,
           :ssh => {


### PR DESCRIPTION
This PR fixes specifying custom specs by name. Also, sometimes our VMs get IPv6 addresses first and the driver tries to use them, causing failures because our network doesn't yet support IPv6. I added an option that forces the driver to wait for an IPv4 address before connecting.