### PR TITLE
attempt to fix dhcp bug where it uses a bogus ip

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -360,7 +360,7 @@ module ChefProvisioningVsphere
           connectable = transport_for(
             machine_spec,
             machine_options[:bootstrap_options][:ssh],
-            ip
+            vm_ip
           ).available?
         end
         sleep 5

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -304,7 +304,7 @@ module ChefProvisioningVsphere
     def attempt_ip(machine_options, action_handler, vm, machine_spec)
       vm_ip = ip_to_bootstrap(machine_options[:bootstrap_options], vm)
       
-      wait_for_ip(vm, machine_options, action_handler)
+      wait_for_ip(vm, machine_options, machine_spec, action_handler)
 
       unless has_ip?(vm_ip, vm)
         action_handler.report_progress "rebooting..."
@@ -319,7 +319,7 @@ module ChefProvisioningVsphere
         else
           restart_server(action_handler, machine_spec, machine_options)
         end
-        wait_for_ip(vm, machine_options, action_handler)
+        wait_for_ip(vm, machine_options, machine_spec, action_handler)
       end
     end
 
@@ -342,7 +342,7 @@ module ChefProvisioningVsphere
       end
     end
 
-    def wait_for_ip(vm, machine_options, action_handler)
+    def wait_for_ip(vm, machine_options, machine_spec, action_handler)
       bootstrap_options = machine_options[:bootstrap_options]
       vm_ip = ip_to_bootstrap(bootstrap_options, vm)
       ready_timeout = machine_options[:ready_timeout] || 300
@@ -351,10 +351,18 @@ module ChefProvisioningVsphere
       action_handler.report_progress msg
 
       start = Time.now.utc
-      until (Time.now.utc - start) > ready_timeout || has_ip?(vm_ip, vm) do
+      connectable = false
+      until (Time.now.utc - start) > ready_timeout || connectable do
         action_handler.report_progress(
           "IP addresses found: #{all_ips_for(vm)}")
         vm_ip ||= ip_to_bootstrap(bootstrap_options, vm)
+        if has_ip?(vm_ip, vm)
+          connectable = transport_for(
+            machine_spec,
+            machine_options[:bootstrap_options][:ssh],
+            ip
+          ).available?
+        end
         sleep 5
       end
     end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.2'
+  VERSION = '0.8.3.dev'
 end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.3.dev'
+  VERSION = '0.8.3.dev.2'
 end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.3.dev.2'
+  VERSION = '0.8.3'
 end


### PR DESCRIPTION
This is an attempt to fix #28 and #32 where IPs for VMs provisioned via dhcp are using a bogus IP and therefore connection attempts to those VMs fail. I currently do not have access to workable vsphere infrastructure so I cant yet guarantee the effectiveness of this fix.

There is a dev gem available `0.8.3.dev` with this commit.

For those affected by thus bug and who would like to test this fix, please try installing the dev gem and reporting back here your results.