### PR TITLE
Fix for lacking permissions on vim.serviceInstance.find_datacenter()

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
+++ b/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
@@ -81,7 +81,8 @@ module ChefProvisioningVsphere
     end
 
     def datacenter
-      @datacenter ||= vim.serviceInstance.find_datacenter(datacenter_name) ||
+      rootFolder = vim.serviceInstance.content.rootFolder
+      @datacenter ||= rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == datacenter_name } ||
         raise("vSphere Datacenter not found [#{datacenter_name}]")
     end
 


### PR DESCRIPTION
Currently `vim.serviceInstance.find_datacenter()` requires a higher level of VMware permissions to be executed. I am unsure what the required permissions are and until it can be identified the changes here will provide a workaround.

Original issue: #34