### PR TITLE
ssh_transport should receive a hash as options

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -662,7 +662,7 @@ module ChefProvisioningVsphere
       Chef::Provisioning::Transport::SSH.new(
         host,
         ssh_user,
-        options,
+        options.to_hash,
         @config[:machine_options][:sudo] ? {:prefix => 'sudo '} : {},
         config
       )


### PR DESCRIPTION
Use hash instead of Cheffish::MergedConfig when instantiating
Chef::Provisioning::Transport::SSH #59

