### PR TITLE
Update syntax in kitchen.yml example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ end
 This chef-provisioning-driver comes with a test-kitchen driver. Here are example driver options you can add to your `kitchen.yml`.
 
 ```
-driver_plugin: vsphere
-driver_config:
+driver:
+  name: vsphere
   driver_options:
     host: '1.2.3.5'
     user: 'user'


### PR DESCRIPTION
The syntax in the example is in the old kitchen.yml syntax, and can be
somewhat confusing if you are not familiar with chef provisioning or
the old kitchen syntax. This updates the example to make it a little
easier to understand and use.