### PR TITLE
Accomodate SSL and Negotiate transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ This will use chef-zero and needs no chef server (only works for ssh). Note that
 - `[:customization_spec][:hostname]` - hostname to use. Defaults to machine resource name if not provided
 - `[:customization_spec][:org_name]` - org name used in sysprep on windows
 - `[:customization_spec][:product_id]` - windows product key
-- `[:customization_spec][:run_once]` - commands for vSphere to run at the end of windows bootstrapping; set this to your own array to override the [default winrm setup options](http://www.rubydoc.info/gems/chef-provisioning-vsphere/ChefProvisioningVsphere%2FHelpers%3Awindows_prep_for)
+- `[:customization_spec][:run_once]` - Array of commands for vSphere to run at the end of windows bootstrapping
 - `[:customization_spec][:time_zone]` - The case-sensitive timezone, such as Europe/Sofia based on the tz (timezone) database used by Linux and other Unix systems
-- `[:customization_spec][:transport]` - winrm transport to use. Defaults to `plaintext`
+- `[:customization_spec][:winrm_transport]` - winrm transport to use. Defaults to `negotiate`
 - `[:customization_spec][:win_time_zone]` - numeric time zone for windows
 - `[:customization_spec][:winrm_opts]` - Optional hash of [winrm options](https://github.com/WinRb/WinRM) (e.g. `disable_sspi: true`)
 

--- a/chef-provisioning-vsphere.gemspec
+++ b/chef-provisioning-vsphere.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rbvmomi', '~> 1.8.0', '>= 1.8.2'
   s.add_dependency 'chef-provisioning', '~>1.1'
+  s.add_dependency 'winrm', '~> 1.6'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
+++ b/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
@@ -160,22 +160,8 @@ module ChefProvisioningVsphere
 
     def windows_prep_for(options, vm_name)
       cust_options = options[:customization_spec]
-      Chef::Log.warn('Using default insecure WinRM setup commands') if
-        cust_options[:run_once].nil?
-      command_list =
-        case cust_options[:run_once].nil?
-        when true
-          [
-            'winrm set winrm/config/client/auth @{Basic="true"}',
-            'winrm set winrm/config/service/auth @{Basic="true"}',
-            'winrm set winrm/config/service @{AllowUnencrypted="true"}',
-            'shutdown -l'
-          ]
-        else
-          cust_options[:run_once]
-        end
       cust_runonce = RbVmomi::VIM::CustomizationGuiRunOnce.new(
-        :commandList => command_list)
+        :commandList => cust_options[:run_once]) unless cust_options[:run_once].nil?
 
       cust_login_password = RbVmomi::VIM::CustomizationPassword(
         :plainText => true,

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -641,9 +641,9 @@ module ChefProvisioningVsphere
 
     def create_winrm_transport(host, options)
       require 'chef/provisioning/transport/winrm'
-      port = options[:port].nil? ? '5985' : options[:port]
       winrm_transport =
-        options[:transport].nil? ? :plaintext : options[:transport].to_sym
+        options[:winrm_transport].nil? ? :negotiate : options[:winrm_transport].to_sym
+      port = options[:port] || winrm_transport == :ssl ? '5986' : '5985'
       winrm_options = {
         user: "#{options[:user]}",
         pass: options[:password]

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.4'
+  VERSION = '0.9.0'
 end

--- a/spec/integration_tests/vsphere_driver_spec.rb
+++ b/spec/integration_tests/vsphere_driver_spec.rb
@@ -94,7 +94,7 @@ describe 'vsphere_driver' do
     end
     it 'is in the correct host' do
       if @metal_config[:machine_options][:bootstrap_options].has_key?(:host)
-        expect(@vm.runtime.host.name).to eq(@metal_config[:machine_options][:bootstrap_options][:host].split('/')[1])
+        expect(@vm.runtime.host.name).to eq(@metal_config[:machine_options][:bootstrap_options][:host].split('/').last)
       end
     end
     it 'is in the correct cluster' do


### PR DESCRIPTION
This takes the commits from #42 and then modernizes the winrm transport based on improvements we made late last year supporting negotiate over both windows and linux hosts and eliminating the need for plaintext authorization.